### PR TITLE
add Image.onerror handler so the returned promise gives more control

### DIFF
--- a/src/ahdin.factory.js
+++ b/src/ahdin.factory.js
@@ -30,11 +30,17 @@
       var imageDeferred = $q.defer();
       var image = new Image();
       image.onload = resolveImage;
+      image.onerror = rejectImage;
       image.src = blobUtil.createObjectURL(params.sourceFile);
       return imageDeferred.promise;
 
       function resolveImage() {
         imageDeferred.resolve(image);
+        $rootScope.$apply();
+      }
+      
+      function rejectImage(err) {
+        imageDeferred.reject(err, image);
         $rootScope.$apply();
       }
     }


### PR DESCRIPTION
Stumbled upon a case on iOS 8.0 where Safari fails to create the BLOB URL (plenty of instances of such issue on Google).  This change allows the client to handle such errors.
